### PR TITLE
remove deprecated class container logic

### DIFF
--- a/osmosis/src/index.js
+++ b/osmosis/src/index.js
@@ -1,10 +1,9 @@
 import { StoreProvider } from './storeProvider.js';
-import { Container, setupStore } from './setupStore.js';
+import { setupStore } from './setupStore.js';
 import { usePersistedState, configureUsePersistedState } from './usePersistedState.js';
 
-export { Container, setupStore, StoreProvider, usePersistedState, configureUsePersistedState };
+export { setupStore, StoreProvider, usePersistedState, configureUsePersistedState };
 export default {
-  Container,
   setupStore,
   StoreProvider,
   usePersistedState,

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -1,13 +1,5 @@
 import React, { createContext } from 'react';
 
-class Container {
-  constructor() {
-    this.container = {
-      state: {}
-    };
-  }
-}
-
 /**
  * @callback useCustomHook
  * @returns {Object}
@@ -15,31 +7,26 @@ class Container {
 
 /**
  * @param {useCustomHook} useCustomHook
- * @param {Object=} classContainer - Deprecated: classContainer support will be removed in a future release
  * @returns {Object[]}
  */
-const setupStore = (useCustomHook, classContainer) => {
+const setupStore = useCustomHook => {
   const StoreContext = createContext();
-  let store = { state: {} };
+  let storeRef = { state: {} };
 
   const withStoreContext = WrappedComponent => props => {
-    let container = useCustomHook();
-    if (classContainer) {
-      classContainer.container = container;
-    } else {
-      for (let key in container) {
-        store[key] = container[key];
-      }
+    let store = useCustomHook();
+    for (let key in store) {
+      storeRef[key] = store[key];
     }
 
     return (
-      <StoreContext.Provider value={[container]}>
+      <StoreContext.Provider value={[store]}>
         <WrappedComponent {...props} />
       </StoreContext.Provider>
     );
   };
 
-  return [StoreContext, withStoreContext, store];
+  return [StoreContext, withStoreContext, storeRef];
 };
 
-export { Container, setupStore };
+export { setupStore };


### PR DESCRIPTION
I'm removing the old class container logic ref, since this is a pattern that we no longer want to use or support.