### PR TITLE
allow proxy opt in

### DIFF
--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -63,7 +63,11 @@ const setupStore = (useCustomHook, config = _defaultConfig) => {
       },
       set: (target, property, value) => (target.ref[property] = value)
     });
+  } else {
+    storeRef.Context = StoreContext;
+    storeRef.Provider = withStoreContext;
   }
+
 
   return storeProxy || storeRef;
 };

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -1,25 +1,50 @@
 import React, { createContext } from 'react';
 
+const _defaultConfig = { proxyEnabled: false };
+
 /**
  * @callback useCustomHook
  * @returns {Object}
  */
 
 /**
- * @param {useCustomHook} useCustomHook
- * @returns {Object[]}
+ *  @typedef SetupStoreConfig
+ *  @type {Object}
+ *  @property {boolean} proxyEnabled - Determines if the store setup should use proxies internally for the store ref, only if proxies are supported
  */
-const setupStore = useCustomHook => {
+
+/**
+ *  @typedef Store
+ *  @type {Object}
+ *  @property {Object} Context - The React Context for the store
+ *  @property {Object} Provider - The higher order component provider for the store
+ */
+
+/**
+ * @param {useCustomHook} useCustomHook
+ * @param {SetupStoreConfig} [config = { proxyEnabled: false }] - The setup store config
+ * @returns {Store}
+ */
+const setupStore = (useCustomHook, config = _defaultConfig) => {
   const StoreContext = createContext();
+  // If proxy is not supported
   let storeRef = { state: {} };
+
+  // If proxy is supported
+  let storeProxy;
+  let storeProxyObject = { ref: { state: {} } };
 
   const withStoreContext = WrappedComponent => props => {
     let store = useCustomHook();
     if (!!store.Context) throw new Error("'Context' property is protected and cannot exist on a store object");
     if (!!store.Provider) throw new Error("'Provider' property is protected and cannot exist on a store object");
 
-    for (let key in store) {
-      storeRef[key] = store[key];
+    if (storeProxy) {
+      storeProxyObject.ref = store;
+    } else {
+      for (let key in store) {
+        storeRef[key] = store[key];
+      }
     }
 
     return (
@@ -28,9 +53,19 @@ const setupStore = useCustomHook => {
       </StoreContext.Provider>
     );
   };
-  storeRef.Context = StoreContext;
-  storeRef.Provider = withStoreContext;
-  return storeRef;
+
+  if (!!Proxy && config.proxyEnabled) {
+    storeProxy = new Proxy(storeProxyObject, {
+      get: (target, property) => {
+        if (property === 'Context') return StoreContext;
+        if (property === 'Provider') return withStoreContext;
+        return target.ref[property];
+      },
+      set: (target, property, value) => (target.ref[property] = value)
+    });
+  }
+
+  return storeProxy || storeRef;
 };
 
 export { setupStore };


### PR DESCRIPTION
I'm testing out moving to proxied store refs, if supported. I've been able to show that internally this is much more performant as we do not have to iterate over the store to populate all the storeRef properties.

For now, this will be opt in so we can keep testing it. Eventually, if this proves to be solid and reliable, we can look at making it the default experience.