### PR TITLE
fix persisted falsy value causing default value to come back

### DIFF
--- a/osmosis/src/usePersistedState.js
+++ b/osmosis/src/usePersistedState.js
@@ -27,7 +27,7 @@ export const usePersistedState = (initValue, key) => {
     if (getItem) persistedValue = await getItem(key);
     setState(state => {
       return {
-        value: persistedValue || state.value,
+        value: persistedValue ?? state.value,
         isLoaded: true
       };
     });


### PR DESCRIPTION
if the stored persisted value comes back as falsy, this was causing the default value to be used instead of the persisted falsy value. The change to check for nullish instead of falsy should resolve this.