### PR TITLE
Store provider migration and rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist/
 node_modules/
+
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v2.0.0
+* BREAKING CHANGE - When subscribing to a store via the `useContext` hook, the returning store object is now a single object which represents the store. Previously this was an array, but the array was arbitrary.
+* chore/bug - Reworked store providers to correctly target rerenders only to subscribing children components. Previously there was a nuance where updates could occur even without a context subscription.
+
 ## v1.3.0
 * feature - support multiple dynamic stores and forwarding props into the store custom hooks
 * chore - fix persisted falsy value causing default value to come back

--- a/examples/counter-react/src/__tests__/counter.spec.js
+++ b/examples/counter-react/src/__tests__/counter.spec.js
@@ -12,7 +12,7 @@ describe('Counter', () => {
     decrementCount: jest.fn()
   };
   let ContextComponent = () => (
-    <CounterStore.Context.Provider value={[counterStore]}>
+    <CounterStore.Context.Provider value={counterStore}>
       <Counter />
     </CounterStore.Context.Provider>
   );

--- a/examples/counter-react/src/counter.js
+++ b/examples/counter-react/src/counter.js
@@ -2,16 +2,16 @@ import React, { useContext } from 'react';
 import { CounterStore } from './store';
 
 const Counter = () => {
-  const [counterContext] = useContext(CounterStore.Context);
-  let { count } = counterContext.state;
+  const counterStore = useContext(CounterStore.Context);
+  let { count } = counterStore.state;
 
   return (
     <div data-testid="counter-wrap">
       <p>Count: {count}</p>
-      <button data-testid="decrement" onClick={counterContext.decrementCount}>
+      <button data-testid="decrement" onClick={counterStore.decrementCount}>
         -
       </button>
-      <button data-testid="increment" onClick={counterContext.incrementCount}>
+      <button data-testid="increment" onClick={counterStore.incrementCount}>
         +
       </button>
     </div>

--- a/examples/counter-react/src/counterByName.js
+++ b/examples/counter-react/src/counterByName.js
@@ -2,8 +2,8 @@ import React, { useContext } from 'react';
 import { CounterStore } from './store';
 
 const Counter = ({ name }) => {
-  const [counterContext] = useContext(CounterStore.Context);
-  let { count } = counterContext.state;
+  const counterStore = useContext(CounterStore.Context);
+  let { count } = counterStore.state;
 
   // this isn't necessary, but this demonstrates how a store ref would be used if a storeKey is provided
   const incrementCount = () => CounterStore[name].incrementCount();
@@ -13,7 +13,7 @@ const Counter = ({ name }) => {
       <p>
         Counter with key {name}: {count}
       </p>
-      <button data-testid="decrement" onClick={counterContext.decrementCount}>
+      <button data-testid="decrement" onClick={counterStore.decrementCount}>
         -
       </button>
       <button data-testid="increment" onClick={incrementCount}>

--- a/examples/counter-react/src/counterByName.js
+++ b/examples/counter-react/src/counterByName.js
@@ -1,12 +1,12 @@
 import React, { useContext } from 'react';
-import { CounterStore } from './store';
+import { DynamicCounterStore } from './store';
 
 const Counter = ({ name }) => {
-  const counterStore = useContext(CounterStore.Context);
+  const counterStore = useContext(DynamicCounterStore.Context);
   let { count } = counterStore.state;
 
   // this isn't necessary, but this demonstrates how a store ref would be used if a storeKey is provided
-  const incrementCount = () => CounterStore[name].incrementCount();
+  const incrementCount = () => DynamicCounterStore[name].incrementCount();
 
   return (
     <div data-testid="counter-wrap">
@@ -23,4 +23,4 @@ const Counter = ({ name }) => {
   );
 };
 
-export default CounterStore.Provider(Counter);
+export default DynamicCounterStore.Provider(Counter);

--- a/examples/counter-react/src/dispatchCounter.js
+++ b/examples/counter-react/src/dispatchCounter.js
@@ -2,8 +2,8 @@ import React, { useContext } from 'react';
 import { CounterWithReducerStore } from './store';
 
 const PersistedCounter = () => {
-  const [counterContext] = useContext(CounterWithReducerStore.Context);
-  let { dispatch, counterState: { count }} = counterContext;
+  const counterStore = useContext(CounterWithReducerStore.Context);
+  let { dispatch, counterState: { count }} = counterStore;
 
   return (
     <div data-testid="counter-wrap">

--- a/examples/counter-react/src/persistedCounter.js
+++ b/examples/counter-react/src/persistedCounter.js
@@ -2,16 +2,16 @@ import React, { useContext } from 'react';
 import { CounterStore } from './store';
 
 const PersistedCounter = () => {
-  const [counterContext] = useContext(CounterStore.Context);
-  let { persistedCount } = counterContext.state;
+  const counterStore = useContext(CounterStore.Context);
+  let { persistedCount } = counterStore.state;
 
   return (
     <div data-testid="counter-wrap">
       <p>Persisted Count: {persistedCount}</p>
-      <button data-testid="decrement" onClick={counterContext.decrementPersistedCount}>
+      <button data-testid="decrement" onClick={counterStore.decrementPersistedCount}>
         -
       </button>
-      <button data-testid="increment" onClick={counterContext.incrementPersistedCount}>
+      <button data-testid="increment" onClick={counterStore.incrementPersistedCount}>
         +
       </button>
     </div>

--- a/examples/counter-react/src/store/__tests__/counter.store.spec.js
+++ b/examples/counter-react/src/store/__tests__/counter.store.spec.js
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import CounterStore  from '../counter.store';
+import { CounterStore } from '../counter.store';
 import { render } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 

--- a/examples/counter-react/src/store/__tests__/counter.store.spec.js
+++ b/examples/counter-react/src/store/__tests__/counter.store.spec.js
@@ -7,7 +7,7 @@ describe('CounterStore', () => {
   let store;
   const renderStore = () => {
     let Prep = CounterStore.Provider(() => {
-      store = useContext(CounterStore.Context)[0];
+      store = useContext(CounterStore.Context);
       return null;
     });
     render(<Prep />);

--- a/examples/counter-react/src/store/counter.store.js
+++ b/examples/counter-react/src/store/counter.store.js
@@ -28,5 +28,6 @@ const useCounterContainer = () => {
 };
 
 let CounterStore = setupStore(useCounterContainer);
+let DynamicCounterStore = setupStore(useCounterContainer);
 
-export default CounterStore ;
+export { CounterStore, DynamicCounterStore };

--- a/examples/counter-react/src/store/index.js
+++ b/examples/counter-react/src/store/index.js
@@ -1,2 +1,2 @@
-export { default as CounterStore } from './counter.store';
+export { CounterStore, DynamicCounterStore } from './counter.store';
 export { default as CounterWithReducerStore } from './counterWithReducer.store.js';

--- a/osmosis/README.md
+++ b/osmosis/README.md
@@ -86,7 +86,7 @@ import React, { useContext } from 'react';
 import { CounterStore } from './counter.store';
 
 export default () => {
-  const [counterStore] = useContext(CounterStore.Context);
+  const counterStore = useContext(CounterStore.Context);
   let { count } = counterStore.state;
 
   return (

--- a/osmosis/package.json
+++ b/osmosis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipt/osmosis",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "A lightweight state management library for React and React Native",
   "keywords": [
     "react",

--- a/osmosis/src/index.js
+++ b/osmosis/src/index.js
@@ -1,10 +1,11 @@
 import { StoreProvider } from './storeProvider.js';
-import { setupStore } from './setupStore.js';
+import { setupStore, configureSetupStore } from './setupStore.js';
 import { usePersistedState, configureUsePersistedState } from './usePersistedState.js';
 
-export { setupStore, StoreProvider, usePersistedState, configureUsePersistedState };
+export { setupStore, configureSetupStore, StoreProvider, usePersistedState, configureUsePersistedState };
 export default {
   setupStore,
+  configureSetupStore,
   StoreProvider,
   usePersistedState,
   configureUsePersistedState

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -40,7 +40,8 @@ const setupStore = (useCustomHook, config = {}) => {
   let storeProxy;
   let storeProxyObject = { ref: {} };
 
-  const withStoreContext = WrappedComponent => props => {
+  // Legacy Store Provider
+  const withLegacyStoreContext = WrappedComponent => props => {
     let storeKey = props.storeKey;
     let store = useCustomHook(props);
     if (!!store.Context) throw new Error("'Context' property is protected and cannot exist on a store object");
@@ -69,7 +70,8 @@ const setupStore = (useCustomHook, config = {}) => {
     );
   };
 
-  const withStoreContext2 = WrappedComponent => props => (
+  // New Store Provider
+  const withStoreContext = WrappedComponent => props => (
     <StoreContextWrapper {...props}>
       <WrappedComponent {...props} />
     </StoreContextWrapper>
@@ -105,7 +107,7 @@ const setupStore = (useCustomHook, config = {}) => {
       get: (target, property) => {
         if (property === 'Context') return StoreContext;
         if (property === 'Provider') return withStoreContext;
-        if (property === 'Provider2') return withStoreContext2;
+        if (property === 'LegacyProvider') return withLegacyStoreContext;
         return target.ref[property];
       },
       set: (target, property, value) => (target.ref[property] = value)
@@ -113,6 +115,7 @@ const setupStore = (useCustomHook, config = {}) => {
   } else {
     storeRef.Context = StoreContext;
     storeRef.Provider = withStoreContext;
+    storeRef.LegacyProvider = withLegacyStoreContext;
   }
 
   return storeProxy || storeRef;

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { createContext } from 'react';
 
 let _defaultConfig = { proxyEnabled: true, legacyReturnStoreAsArray: false };
@@ -71,7 +72,7 @@ const setupStore = (useCustomHook, config = {}) => {
   };
 
   // New Store Provider
-  const withStoreContext = WrappedComponent => props => {
+  const withStoreContext = WrappedComponent => {
     const StoreContextWrapper = ({ children, ...props }) => {
       let storeKey = props.storeKey;
       let store = useCustomHook(props);
@@ -97,11 +98,12 @@ const setupStore = (useCustomHook, config = {}) => {
       return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>;
     };
 
-    return (
+    const Wrapper = props => (
       <StoreContextWrapper {...props}>
         <WrappedComponent {...props} />
       </StoreContextWrapper>
     );
+    return Wrapper;
   };
 
   if (!!Proxy && config.proxyEnabled) {


### PR DESCRIPTION
- Updating the structure returned when subscribing to a store via the `useContext` hook. Previously the result came back as an array, and now it will simply return the store object directly
- Reworked the store provider logic (compliments of @rkyle35242) to fix a structural bug in the component tree which seemed to have negative impacts when mixing HoC's and Context....now Context updates are always correctly applied to only their subscribers
- Updated example projects to have new structure
- Fixed bug in dynamic stores example due to it sharing a store with another example (broke out the stores to separate instances)
- Version update prepped for the release
- Changelog updates, documenting breaking change details, etc...
- Updated readme docs to reflect changes accordingly

Demo:
In this demo I've added logging to the main 2 stores in the examples project in this repo, and then changed the store provider wrapper and observed the difference in renders...

BEFORE (Legacy Store Provider)
![before](https://user-images.githubusercontent.com/7785308/151260905-bdf4e09e-763c-48a2-b9ae-f88fe859f9ad.gif)

AFTER (New Store Provider)
![after](https://user-images.githubusercontent.com/7785308/151260923-9e354f07-e90c-4212-855f-8bc2a02a04ed.gif)