### PR TITLE
type the returned ref

### DIFF
--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -27,9 +27,10 @@ export const configureSetupStore = config => {
  */
 
 /**
- * @param {useCustomHook} useCustomHook
+ * @template T
+ * @param {function(object) : T} useCustomHook
  * @param {SetupStoreConfig} [config = { proxyEnabled: false }] - The setup store config
- * @returns {Store}
+ * @returns {T & Store}
  */
 const setupStore = (useCustomHook, config = {}) => {
   config = { ..._defaultConfig, ...config };

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { createContext } from 'react';
+import React, { createContext, useContext } from 'react';
 
 let _defaultConfig = { proxyEnabled: true, legacyReturnStoreAsArray: false };
 
@@ -20,9 +20,9 @@ export const configureSetupStore = config => {
  */
 
 /**
+ *  @template T
  *  @typedef Store
- *  @type {Object}
- *  @property {Object} Context - The React Context for the store
+ *  @property {React.Context<T>} Context - The React Context for the store
  *  @property {Object} Provider - The higher order component provider for the store
  */
 
@@ -30,7 +30,7 @@ export const configureSetupStore = config => {
  * @template T
  * @param {function(object) : T} useCustomHook
  * @param {SetupStoreConfig} [config = { proxyEnabled: false }] - The setup store config
- * @returns {T & Store}
+ * @returns {T & Store<T>}
  */
 const setupStore = (useCustomHook, config = {}) => {
   config = { ..._defaultConfig, ...config };

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { createContext, useContext } from 'react';
+import React, { createContext } from 'react';
 
 let _defaultConfig = { proxyEnabled: true, legacyReturnStoreAsArray: false };
 


### PR DESCRIPTION
When invoking the store ref returned by `setupStore`, it's annoying to have to go back to the file to see not only the name of the function you want, but also the call signature. This patches that hole.

<img width="538" alt="image" src="https://user-images.githubusercontent.com/24547965/166734979-93ce8c82-93e3-4761-9cff-e7eaf3e564c4.png">

<img width="367" alt="image" src="https://user-images.githubusercontent.com/24547965/166735097-a8c944b7-0b45-4439-b437-a56204a877c0.png">


