### PR TITLE
useStore hook returned on Store ref

### DIFF
--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -55,7 +55,7 @@ const setupStore = (useCustomHook, config = {}) => {
     let store = useCustomHook(props);
     if (!!store.Context) throw new Error("'Context' property is protected and cannot exist on a store object");
     if (!!store.Provider) throw new Error("'Provider' property is protected and cannot exist on a store object");
-    if (!!store.useStore) throw new Error("'Provider' property is protected and cannot exist on a store object");
+    if (!!store.useStore) throw new Error("'useStore' property is protected and cannot exist on a store object");
 
     if (storeProxy) {
       if (storeKey) {
@@ -87,6 +87,7 @@ const setupStore = (useCustomHook, config = {}) => {
       let store = useCustomHook(props);
       if (!!store.Context) throw new Error("'Context' property is protected and cannot exist on a store object");
       if (!!store.Provider) throw new Error("'Provider' property is protected and cannot exist on a store object");
+      if (!!store.useStore) throw new Error("'useStore' property is protected and cannot exist on a store object");
 
       if (storeProxy) {
         if (storeKey) {
@@ -118,12 +119,12 @@ const setupStore = (useCustomHook, config = {}) => {
   const useStore = () => useContext(StoreContext);
 
   if (!!Proxy && config.proxyEnabled) {
-    storeProxyObject.ref['useStore'] = useStore;
     storeProxy = new Proxy(storeProxyObject, {
       get: (target, property) => {
         if (property === 'Context') return StoreContext;
         if (property === 'Provider') return withStoreContext;
         if (property === 'LegacyProvider') return withLegacyStoreContext;
+        if (property === 'useStore') return target.ref[property] ?? useStore;
         return target.ref[property];
       },
       set: (target, property, value) => (target.ref[property] = value)

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -55,6 +55,7 @@ const setupStore = (useCustomHook, config = {}) => {
     let store = useCustomHook(props);
     if (!!store.Context) throw new Error("'Context' property is protected and cannot exist on a store object");
     if (!!store.Provider) throw new Error("'Provider' property is protected and cannot exist on a store object");
+    if (!!store.useStore) throw new Error("'Provider' property is protected and cannot exist on a store object");
 
     if (storeProxy) {
       if (storeKey) {

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { createContext } from 'react';
+import React, { createContext, useContext } from 'react';
 
 let _defaultConfig = { proxyEnabled: true, legacyReturnStoreAsArray: false };
 
@@ -20,10 +20,17 @@ export const configureSetupStore = config => {
  */
 
 /**
+ * @template T
+ * @callback useStore
+ * @returns {T}
+ */
+
+/**
  *  @template T
  *  @typedef Store
  *  @property {React.Context<T>} Context - The React Context for the store
  *  @property {Object} Provider - The higher order component provider for the store
+ *  @property {useStore<T>} useStore - Returns result of useContext(Context)
  */
 
 /**
@@ -107,7 +114,10 @@ const setupStore = (useCustomHook, config = {}) => {
     return Wrapper;
   };
 
+  const useStore = () => useContext(StoreContext);
+
   if (!!Proxy && config.proxyEnabled) {
+    storeProxyObject['useStore'] = useStore;
     storeProxy = new Proxy(storeProxyObject, {
       get: (target, property) => {
         if (property === 'Context') return StoreContext;
@@ -121,6 +131,7 @@ const setupStore = (useCustomHook, config = {}) => {
     storeRef.Context = StoreContext;
     storeRef.Provider = withStoreContext;
     storeRef.LegacyProvider = withLegacyStoreContext;
+    storeRef.useStore = useStore;
   }
 
   return storeProxy || storeRef;

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -118,7 +118,7 @@ const setupStore = (useCustomHook, config = {}) => {
   const useStore = () => useContext(StoreContext);
 
   if (!!Proxy && config.proxyEnabled) {
-    storeProxyObject['useStore'] = useStore;
+    storeProxyObject.ref['useStore'] = useStore;
     storeProxy = new Proxy(storeProxyObject, {
       get: (target, property) => {
         if (property === 'Context') return StoreContext;


### PR DESCRIPTION
Including a manner by which to consume the resulting Store on the ref allows easy mocking in tests.

Usage:

<img width="611" alt="image" src="https://user-images.githubusercontent.com/24547965/169352912-bc04436f-f2d2-4478-bc05-cc1abe318996.png">

Tests:

|Before|After|
|---|---|
|<img width="801" alt="image" src="https://user-images.githubusercontent.com/24547965/169353019-65b854dd-8f80-4485-98b8-7c5c06742e9c.png">|<img width="807" alt="image" src="https://user-images.githubusercontent.com/24547965/169352991-c608b263-9db9-4561-a818-5d1834003c00.png">|