### PR TITLE
name the wrapper for easier debugging

### DIFF
--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -83,6 +83,8 @@ const setupStore = (useCustomHook, config = {}) => {
         <WrappedComponent {...props} />
       </StoreContextWrapper>
     );
+    const name = useCustomHook.name;
+    Wrapper.displayName = `${name.charAt(0).toUpperCase() + name.slice(1)}Wrapper`;
     return Wrapper;
   };
 

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -83,8 +83,7 @@ const setupStore = (useCustomHook, config = {}) => {
         <WrappedComponent {...props} />
       </StoreContextWrapper>
     );
-    const name = useCustomHook.name;
-    Wrapper.displayName = `${name.charAt(0).toUpperCase() + name.slice(1)}Wrapper`;
+    Wrapper.displayName = `${useCustomHook.name}Wrapper`;
     return Wrapper;
   };
 


### PR DESCRIPTION
Tracing callstacks in the metro bundler is nearly impossible with every store provider wrapper named `Wrapper`. We should name them.

Example result before I cleaned up the capitalization:
<img width="244" alt="image" src="https://user-images.githubusercontent.com/24547965/178800027-cad7cef8-d46d-4058-90da-b4e1f3a61274.png">
