### PR TITLE
Migrate examples to useStore

### DIFF
--- a/examples/counter-react/src/counter.js
+++ b/examples/counter-react/src/counter.js
@@ -1,17 +1,20 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { CounterStore } from './store';
 
 const Counter = () => {
-  const counterStore = useContext(CounterStore.Context);
-  let { count } = counterStore.state;
+  const {
+    state: { count },
+    decrementCount,
+    incrementCount
+  } = CounterStore.useStore();
 
   return (
     <div data-testid="counter-wrap">
       <p>Count: {count}</p>
-      <button data-testid="decrement" onClick={counterStore.decrementCount}>
+      <button data-testid="decrement" onClick={decrementCount}>
         -
       </button>
-      <button data-testid="increment" onClick={counterStore.incrementCount}>
+      <button data-testid="increment" onClick={incrementCount}>
         +
       </button>
     </div>


### PR DESCRIPTION
Draft PR for conversation

I'd be in favor of migrating all of our examples and documentation over to `useStore()`. After some time using the new syntax I find it more declarative and simple and I haven't been finding reason to go back to `useContext(Context)`.

Creating this PR in the most minimal and simple way possible in order to get feedback. If there's support for changing the docs and examples over to `useStore()` based on this example I will change the rest of them in a full-fledged PR.