### PR TITLE
Finish migrating examples to useStore

### DIFF
--- a/examples/counter-react/src/counter.js
+++ b/examples/counter-react/src/counter.js
@@ -1,17 +1,20 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { CounterStore } from './store';
 
 const Counter = () => {
-  const counterStore = useContext(CounterStore.Context);
-  let { count } = counterStore.state;
+  const {
+    state: { count },
+    decrementCount,
+    incrementCount
+  } = CounterStore.useStore();
 
   return (
     <div data-testid="counter-wrap">
       <p>Count: {count}</p>
-      <button data-testid="decrement" onClick={counterStore.decrementCount}>
+      <button data-testid="decrement" onClick={decrementCount}>
         -
       </button>
-      <button data-testid="increment" onClick={counterStore.incrementCount}>
+      <button data-testid="increment" onClick={incrementCount}>
         +
       </button>
     </div>

--- a/examples/counter-react/src/counterByName.js
+++ b/examples/counter-react/src/counterByName.js
@@ -1,9 +1,11 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { DynamicCounterStore } from './store';
 
 const Counter = ({ name }) => {
-  const counterStore = useContext(DynamicCounterStore.Context);
-  let { count } = counterStore.state;
+  const {
+    state: { count },
+    decrementCount
+  } = DynamicCounterStore.useStore();
 
   // this isn't necessary, but this demonstrates how a store ref would be used if a storeKey is provided
   const incrementCount = () => DynamicCounterStore[name].incrementCount();
@@ -13,7 +15,7 @@ const Counter = ({ name }) => {
       <p>
         Counter with key {name}: {count}
       </p>
-      <button data-testid="decrement" onClick={counterStore.decrementCount}>
+      <button data-testid="decrement" onClick={decrementCount}>
         -
       </button>
       <button data-testid="increment" onClick={incrementCount}>

--- a/examples/counter-react/src/dispatchCounter.js
+++ b/examples/counter-react/src/dispatchCounter.js
@@ -1,17 +1,19 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { CounterWithReducerStore } from './store';
 
 const PersistedCounter = () => {
-  const counterStore = useContext(CounterWithReducerStore.Context);
-  let { dispatch, counterState: { count }} = counterStore;
+  const {
+    dispatch,
+    counterState: { count }
+  } = CounterWithReducerStore.useStore();
 
   return (
     <div data-testid="counter-wrap">
       <p>Dispatch Count: {count}</p>
-      <button data-testid="decrement" onClick={() => dispatch({type: 'decrement'})}>
+      <button data-testid="decrement" onClick={() => dispatch({ type: 'decrement' })}>
         -
       </button>
-      <button data-testid="increment" onClick={() => dispatch({type: 'increment'})}>
+      <button data-testid="increment" onClick={() => dispatch({ type: 'increment' })}>
         +
       </button>
     </div>

--- a/examples/counter-react/src/persistedCounter.js
+++ b/examples/counter-react/src/persistedCounter.js
@@ -1,17 +1,20 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { CounterStore } from './store';
 
 const PersistedCounter = () => {
-  const counterStore = useContext(CounterStore.Context);
-  let { persistedCount } = counterStore.state;
+  const {
+    state: { persistedCount },
+    decrementPersistedCount,
+    incrementPersistedCount
+  } = CounterStore.useStore();
 
   return (
     <div data-testid="counter-wrap">
       <p>Persisted Count: {persistedCount}</p>
-      <button data-testid="decrement" onClick={counterStore.decrementPersistedCount}>
+      <button data-testid="decrement" onClick={decrementPersistedCount}>
         -
       </button>
-      <button data-testid="increment" onClick={counterStore.incrementPersistedCount}>
+      <button data-testid="increment" onClick={incrementPersistedCount}>
         +
       </button>
     </div>

--- a/examples/counter-react/src/store/__tests__/counter.store.spec.js
+++ b/examples/counter-react/src/store/__tests__/counter.store.spec.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { CounterStore } from '../counter.store';
 import { render } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
@@ -7,7 +7,7 @@ describe('CounterStore', () => {
   let store;
   const renderStore = () => {
     let Prep = CounterStore.Provider(() => {
-      store = useContext(CounterStore.Context);
+      store = CounterStore.useStore();
       return null;
     });
     render(<Prep />);

--- a/osmosis/ADVANCED.md
+++ b/osmosis/ADVANCED.md
@@ -56,18 +56,21 @@ export default CounterStore;
 
 ```jsx
 //counter.js
-import React, { useContext } from 'react';
+import React from 'react';
 import { CounterStore } from './counter.store';
 
 export default () => {
-  const [counterStore] = useContext(CounterStore.Context);
-  let { count } = counterStore.state;
+  const {
+    state: { count, interval },
+    increment,
+    decrement
+  } = CounterStore.useStore();
 
   return (
     <div>
       <p>{count}</p>
-      <button onClick={counterStore.increment}>+{interval}</button>
-      <button onClick={counterStore.decrement}>-{interval}</button>
+      <button onClick={increment}>+{interval}</button>
+      <button onClick={decrement}>-{interval}</button>
     </div>
   );
 };
@@ -75,7 +78,7 @@ export default () => {
 
 ```jsx
 //index.js Root Component
-import React from 'react
+import React from 'react'
 import { CounterStore } from './counter.store';
 import Counter from './counter';
 

--- a/osmosis/README.md
+++ b/osmosis/README.md
@@ -82,18 +82,21 @@ export default CounterStore;
 
 ```jsx
 //counter.js
-import React, { useContext } from 'react';
+import React from 'react';
 import { CounterStore } from './counter.store';
 
 export default () => {
-  const counterStore = useContext(CounterStore.Context);
-  let { count } = counterStore.state;
+  const {
+    state: { count },
+    increment,
+    decrement
+  } = CounterStore.useStore();
 
   return (
     <div>
       <p>{count}</p>
-      <button onClick={counterStore.increment}>+</button>
-      <button onClick={counterStore.decrement}>-</button>
+      <button onClick={increment}>+</button>
+      <button onClick={decrement}>-</button>
     </div>
   );
 };
@@ -120,7 +123,7 @@ To configure the persistence layer for `usePersistedState`, simply perform somet
 import { configureUsePersistedState } from '@shipt/osmosis';
 
 async function getItem(key) {
-  let value = // perform async actions to return the value for the key provided 
+  let value = // perform async actions to return the value for the key provided
   return value;
 }
 


### PR DESCRIPTION
This is a continuation of [Tom's draft PR](https://github.com/shipt/osmosis/pull/108/files). Per his suggestion, all instances of `useContext(Context)` in all Osmosis examples, tests and docs have been replaced with `useStore()`. 