### PR TITLE
add ability to register external listeners

### DIFF
--- a/examples/counter-react/src/store/__tests__/counter.store.spec.js
+++ b/examples/counter-react/src/store/__tests__/counter.store.spec.js
@@ -5,6 +5,9 @@ import { act } from 'react-dom/test-utils';
 
 describe('CounterStore', () => {
   let store;
+  let listener = jest.fn();
+  let removeListener;
+
   const renderStore = () => {
     let Prep = CounterStore.Provider(() => {
       store = CounterStore.useStore();
@@ -12,6 +15,14 @@ describe('CounterStore', () => {
     });
     render(<Prep />);
   };
+
+  beforeEach(() => {
+    removeListener = CounterStore.addListener(listener);
+  });
+
+  afterEach(() => {
+    removeListener();
+  });
 
   it('tests increment', () => {
     act(() => {
@@ -21,7 +32,10 @@ describe('CounterStore', () => {
     act(() => {
       store.incrementCount();
     });
+
     expect(store.state.count).toEqual(1);
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith(store);
   });
 
   it('tests decrement', () => {
@@ -33,5 +47,7 @@ describe('CounterStore', () => {
       store.decrementCount();
     });
     expect(store.state.count).toEqual(-1);
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith(store);
   });
 });

--- a/osmosis/README.md
+++ b/osmosis/README.md
@@ -170,3 +170,14 @@ const [stateValue, setStateValue, isHydrated] = usePersistedState(new Map(), 'ma
   getItem: value => new Map(Object.entries(value))    //called with the state value is being hydrated from the persistence layer. value is the JS Object
 });
 ```
+### External Store Listeners
+In rare cases it may be helpful to subscribe to store changes in service files or other files outside the react component hierarchy. In these cases you can add a store listener which gets called with the store object on any updates.
+```js
+const CounterStore = setupStore(useCounterStore);
+
+const unsubscribe = CounterStore.addListener(store => {
+  console.log(store);
+});
+
+unsubscribe();
+```

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -101,6 +101,8 @@ const setupStore = (useCustomHook, config = {}) => {
     return () => (_listeners = _listeners.filter(f => f !== fn));
   };
 
+  const removeAllListeners = () => _listeners = [];
+
   if (!!Proxy && config.proxyEnabled) {
     storeProxy = new Proxy(storeProxyObject, {
       get: (target, property) => {
@@ -108,6 +110,7 @@ const setupStore = (useCustomHook, config = {}) => {
         if (property === 'Provider') return withStoreContext;
         if (property === 'useStore') return target.ref[property] ?? useStore;
         if (property === 'addListener') return addListener;
+        if (property === 'removeAllListeners') return removeAllListeners;
         return target.ref[property];
       },
       set: (target, property, value) => (target.ref[property] = value)
@@ -117,6 +120,7 @@ const setupStore = (useCustomHook, config = {}) => {
     storeRef.Provider = withStoreContext;
     storeRef.useStore = useStore;
     storeRef.addListener = addListener;
+    storeRef.removeAllListeners = removeAllListeners;
   }
 
   return storeProxy || storeRef;

--- a/osmosis/src/setupStore.js
+++ b/osmosis/src/setupStore.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useEffect } from 'react';
 
 let _defaultConfig = { proxyEnabled: true, legacyReturnStoreAsArray: false };
 
@@ -50,6 +50,9 @@ const setupStore = (useCustomHook, config = {}) => {
   let storeProxy;
   let storeProxyObject = { ref: {} };
 
+  //listners
+  let _listeners = [];
+
   // Store Provider
   const withStoreContext = WrappedComponent => {
     const StoreContextWrapper = ({ children, ...props }) => {
@@ -58,6 +61,10 @@ const setupStore = (useCustomHook, config = {}) => {
       if (!!store.Context) throw new Error("'Context' property is protected and cannot exist on a store object");
       if (!!store.Provider) throw new Error("'Provider' property is protected and cannot exist on a store object");
       if (!!store.useStore) throw new Error("'useStore' property is protected and cannot exist on a store object");
+
+      useEffect(() => {
+        _listeners.forEach(fn => fn(store));
+      }, [store]);
 
       if (storeProxy) {
         if (storeKey) {
@@ -89,12 +96,18 @@ const setupStore = (useCustomHook, config = {}) => {
 
   const useStore = () => useContext(StoreContext);
 
+  const addListener = fn => {
+    _listeners.push(fn);
+    return () => (_listeners = _listeners.filter(f => f !== fn));
+  };
+
   if (!!Proxy && config.proxyEnabled) {
     storeProxy = new Proxy(storeProxyObject, {
       get: (target, property) => {
         if (property === 'Context') return StoreContext;
         if (property === 'Provider') return withStoreContext;
         if (property === 'useStore') return target.ref[property] ?? useStore;
+        if (property === 'addListener') return addListener;
         return target.ref[property];
       },
       set: (target, property, value) => (target.ref[property] = value)
@@ -103,6 +116,7 @@ const setupStore = (useCustomHook, config = {}) => {
     storeRef.Context = StoreContext;
     storeRef.Provider = withStoreContext;
     storeRef.useStore = useStore;
+    storeRef.addListener = addListener;
   }
 
   return storeProxy || storeRef;


### PR DESCRIPTION
Allow for registering store listeners on the global store object (outside the react component tree). This allows for external services and code blocks to react to state updates inside the stores.