### PR TITLE
support just passing store to store provider

### DIFF
--- a/osmosis/src/storeProvider.js
+++ b/osmosis/src/storeProvider.js
@@ -1,16 +1,19 @@
 /**
  * @param {Object[]} storeProviders
- * @param {Object} componentToWrap 
+ * @param {Object} componentToWrap
  * @returns {Object} wrappedComponent
  */
 export const StoreProvider = (storeProviders, wrappedComponent) => {
-  if(!Array.isArray(storeProviders)) throw new Error('StoreProvider requires an array of wrapper functions')
-  if(!wrappedComponent) throw new Error('StoreProvider requires a component to wrap')
+  if (!Array.isArray(storeProviders)) throw new Error('StoreProvider requires an array of wrapper functions');
+  if (!wrappedComponent) throw new Error('StoreProvider requires a component to wrap');
 
   try {
-    storeProviders.reverse().forEach(provider => (wrappedComponent = provider(wrappedComponent)));
+    storeProviders.reverse().forEach(provider => {
+      const providerFunction = provider.Provider || provider;
+      wrappedComponent = providerFunction(wrappedComponent);
+    });
     return wrappedComponent;
-  } catch(error) {
-    throw new Error(`StoreProvider encountered an error: ${error.message}`)
+  } catch (error) {
+    throw new Error(`StoreProvider encountered an error: ${error.message}`);
   }
 };


### PR DESCRIPTION
Rather than having to pass `store.Provider`, allow just passing the store directly (with backwards compatibility)

BEFORE:
```js
StoreProvider([Store1.Provider, Store2.Provider, ...])
```

AFTER:
```js
StoreProvider([Store1, Store2, ...])
```