### PR TITLE
chore: update PR template to add security impact section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Problem
+
+> [!NOTE]
+> A linked clickup card somewhere in PR is sufficient
+
+<!--body-->
+
+## Solution
+
+<!-- How did you solve the problem? Were there any additional fixes or changes? -->
+
+## Security Impact
+
+[//]: # (replace this line and document any security impact here)
+[//]: # (If left blank no security impact is assumed)
+
+## Change Verification
+
+### Verification Steps
+
+<!-- Steps to verify the solution to the problem. This should be simple enough that anyone without project context can verify. -->
+<!-- To write instructions, follow https://developers.google.com/style/procedures -->
+
+-
+
+### Security Checklist
+
+- [ ] Verify no lingering test data or test accounts.
+- [ ] Verify no undocumented features exist (implant tools, backdoors).
+- [ ] Confirm secure use of external libraries.
+- [ ] Check for any logging of sensitive data.
+- [ ] Prevent potential injection attacks, including SQL, XSS, CSRF, XXE, LDAP and XPath.
+- [ ] Prevent attacks on data structures, including attempts to manipulate buffers, pointers, input data, or shared data.
+- [ ] Prevent attacks on cryptography usage, including poor implementations, algorithms, cipher suites, or modes of operation.
+- [ ] Prevent attacks on access control mechanisms, including authentication or authorization.
+- [ ] Prevent attacks on any identified "high-risk" vulnerabilities.
+
+## Screenshots
+
+|     BEFORE      |      AFTER      |
+| :-------------: | :-------------: |
+| screenshot_here | screenshot_here |


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? -->
For PCI compliance, PRs must document any security impact and we need to update the PR template for all repos in PCI scope to contain this new section. 

## Solution

<!-- How did you solve the problem? Were there any additional fixes or changes? -->
- Updated PR template to include security impact

## Verification Steps

<!-- Steps to verify the solution to the problem. This should be simple enough that anyone without project context can verify. -->

- Verify template is accurate & all items are applicable